### PR TITLE
Fix phrase handling in Elasticsearch query generator

### DIFF
--- a/src/main/java/org/xbib/cql/elasticsearch/FilterGenerator.java
+++ b/src/main/java/org/xbib/cql/elasticsearch/FilterGenerator.java
@@ -128,7 +128,7 @@ public class FilterGenerator implements Visitor {
                         case ALL: {
                             String field = arg1.toString();
                             String value = arg2 != null ? arg2.toString() : "";
-                            boolean phrase = arg2 instanceof Token && ((Token) arg2).isProtected();
+                            boolean phrase = arg2 instanceof Token && ((Token) arg2).isQuoted();
                             if (phrase) {
                                 builder.startArray("and");
                                 QuotedStringTokenizer qst = new QuotedStringTokenizer(value);
@@ -144,7 +144,7 @@ public class FilterGenerator implements Visitor {
                             break;
                         }
                         case ANY: {
-                            boolean phrase = arg2 instanceof Token && ((Token) arg2).isProtected();
+                            boolean phrase = arg2 instanceof Token && ((Token) arg2).isQuoted();
                             String field = arg1.toString();
                             String value = arg2 != null ? arg2.toString() : "";
                             if (phrase) {

--- a/src/main/java/org/xbib/cql/elasticsearch/QueryGenerator.java
+++ b/src/main/java/org/xbib/cql/elasticsearch/QueryGenerator.java
@@ -194,17 +194,10 @@ public class QueryGenerator implements Visitor {
                             break;
                         }
                         case PHRASE: {
-                            String field = arg1.toString();
-                            String value = arg2 != null ? arg2.toString() : "";
                             if (tok2 != null) {
-                                if (tok2.isQuoted()) {
-                                    builder.startObject("match_phrase")
-                                            .startObject(field)
-                                            .field("query", tok2.getString())
-                                            .field("slop", 0)
-                                            .endObject()
-                                            .endObject();
-                                } else if (tok2.isAll()) {
+                                String field = arg1.toString();
+                                String value = tok2.isQuoted() ? tok2.getString() : arg2.toString();
+                                if (tok2.isAll()) {
                                     builder.startObject("match_all").endObject();
                                 } else if (tok2.isWildcard()) {
                                     builder.startObject("wildcard").field(field, value).endObject();

--- a/src/main/java/org/xbib/cql/elasticsearch/QueryGenerator.java
+++ b/src/main/java/org/xbib/cql/elasticsearch/QueryGenerator.java
@@ -197,7 +197,7 @@ public class QueryGenerator implements Visitor {
                             String field = arg1.toString();
                             String value = arg2 != null ? arg2.toString() : "";
                             if (tok2 != null) {
-                                if (tok2.isProtected()) {
+                                if (tok2.isQuoted()) {
                                     builder.startObject("match_phrase")
                                             .startObject(field)
                                             .field("query", tok2.getString())
@@ -264,7 +264,7 @@ public class QueryGenerator implements Visitor {
                             String from = null;
                             String to = null;
                             if (tok2 != null) {
-                                if (!tok2.isProtected()) {
+                                if (!tok2.isQuoted()) {
                                     throw new IllegalArgumentException("range within: unable to derive range from a non-phrase: " + value);
                                 }
                                 if (tok2.getStringList().size() != 2) {

--- a/src/main/java/org/xbib/cql/elasticsearch/ast/Token.java
+++ b/src/main/java/org/xbib/cql/elasticsearch/ast/Token.java
@@ -22,7 +22,7 @@ public class Token implements Node {
 
     public enum TokenClass {
 
-        NORMAL, ALL, WILDCARD, BOUNDARY, PROTECTED
+        NORMAL, ALL, WILDCARD, BOUNDARY, QUOTED
     }
 
     private TokenType type;
@@ -60,12 +60,12 @@ public class Token implements Node {
 
         }
         if (this.value != null) {
-            // protected?
+            // quoted?
             if (value.startsWith("\"") && value.endsWith("\"")) {
                 this.stringvalue = value;
                 this.value = value.substring(1, value.length() - 1).replaceAll("\\\\\"", "\"");
                 this.values = parseQuot(this.value);
-                tokenClass.add(TokenClass.PROTECTED);
+                tokenClass.add(TokenClass.QUOTED);
             }
             // wildcard?
             if (this.value.indexOf('*') >= 0 || this.value.indexOf('?') >= 0) {
@@ -182,8 +182,8 @@ public class Token implements Node {
         return sb.toString();
     }
 
-    public boolean isProtected() {
-        return tokenClass.contains(TokenClass.PROTECTED);
+    public boolean isQuoted() {
+        return tokenClass.contains(TokenClass.QUOTED);
     }
 
     public boolean isBoundary() {

--- a/src/test/resources/org/xbib/cql/elasticsearch/queries.txt
+++ b/src/test/resources/org/xbib/cql/elasticsearch/queries.txt
@@ -121,3 +121,7 @@ unix and facet.creator = "on" and facet.subject = "on" and facet.date = "off"|{"
 unix and facet.date = on|{"from":0,"size":10,"query":{"bool":{"must":{"simple_query_string":{"query":"unix","fields":["cql.allIndexes"],"analyze_wildcard":true,"default_operator":"and"}}}},"aggregations":{"myfacet":"myvalue"}}
 (cql.allIndexes = "")|{"from":0,"size":10,"query":{"simple_query_string":{"query":"\"\"","fields":["cql.allIndexes"],"analyze_wildcard":true,"default_operator":"and"}}}
 cql.allIndexes all 3125294126|{"from":0,"size":10,"query":{"simple_query_string":{"query":"3125294126","fields":["cql.allIndexes"],"analyze_wildcard":true,"default_operator":"and"}}}
+Item.callnumber adj QAP2230|{"from":0,"size":10,"query":{"match_phrase":{"Item.callnumber":{"query":"QAP2230","slop":0}}}}
+Item.callnumber adj QAP22*|{"from":0,"size":10,"query":{"wildcard":{"Item.callnumber":"QAP22*"}}}
+Item.callnumber adj "K 32/70 A 10"|{"from":0,"size":10,"query":{"match_phrase":{"Item.callnumber":{"query":"K 32/70 A 10","slop":0}}}}
+Item.callnumber adj "K 32/70 A*"|{"from":0,"size":10,"query":{"wildcard":{"Item.callnumber":"K 32/70 A*"}}}

--- a/src/test/resources/org/xbib/cql/queries.txt
+++ b/src/test/resources/org/xbib/cql/queries.txt
@@ -139,3 +139,7 @@ unix and facet.dc.creator = "on" and facet.dc.subject = "on" and facet.dc.subjec
 unix and facet.dc.date = "on" and facet.dc.subject = "on" and facet.dc.subject = "buckets=20"|unix
 unix and facet.dc.creator = "on" and facet.dc.subject = "on" and facet.dc.subject = "buckets=20"|unix
 cql.allIndexes all "linux;"
+Item.callnumber adj QAP2230
+Item.callnumber adj QAP22*
+Item.callnumber adj "K 32/70 A 10"
+Item.callnumber adj "K 32/70 A*"


### PR DESCRIPTION
1. Renamed token class "protected" to "quoted" as it is more in line with remaining nomenclature and stresses syntactic over semantic meaning.

1. Changed query generator to not treat quoted phrases specially. Quoted strings in CQL only have syntactic meaning for the parser and don't carry semantic meaning for the resulting query.

As a consequence of this change, quoted phrases have to be used in their unquoted form (`tok2.getString()` instead of `arg2.toString()`).

NOTE: The `cql.unmasked` relation modifier may be implemented in order to support the previous behaviour of "protected" phrases.